### PR TITLE
Updates for what we've observed in editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # cookiecutter-devnet-learning-lab
 
-A cookiecutter template for creating devnet learning `labs` quickly
+A cookiecutter template for creating DevNet Learning Labs quickly
 
 If you are creating an entirely new module, you may want to start here:
 https://github.com/CiscoDevNet/cookiecutter-devnet-learning-module
 
-If you are working in an existing module, you can add an addtional lab to that
+If you are working in an existing module, you can add an additional lab to that
 module by running the following in the `labs` folder of your existing module.
 
 ## How to use this templates
@@ -35,4 +35,7 @@ another-lab             my-awesome-learning-lab
 
 ## Don't have cookiecutter?
 
-    pip install cookiecutter
+Install it with this command, typically inside a virtual environment:
+   ```
+   $ pip install cookiecutter
+   ```f

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cookiecutter-devnet-learning-lab
 
-A cookiecutter template for creating DevNet Learning Labs quickly
+A `cookiecutter` template for creating DevNet Learning Labs quickly
 
 If you are creating an entirely new module, you may want to start here:
 https://github.com/CiscoDevNet/cookiecutter-devnet-learning-module
@@ -8,10 +8,12 @@ https://github.com/CiscoDevNet/cookiecutter-devnet-learning-module
 If you are working in an existing module, you can add an additional lab to that
 module by running the following in the `labs` folder of your existing module.
 
-## How to use this templates
+## How to use this template
 
-    cookiecutter https://github.com/CiscoDevNet/cookiecutter-devnet-learning-lab
-
+Make sure you install the Python `cookiecutter` library, then use this command to run through template prompts:
+```
+    $ cookiecutter https://github.com/CiscoDevNet/cookiecutter-devnet-learning-lab
+```
 
 
 ## Sample workflow
@@ -26,6 +28,7 @@ my-awesome-learning-lab
 lab_name [my-awesome-learning-lab]: another-lab
 lab_title [lab title]: another title
 lab_slug [One sentence description of the learning lab.]:
+lab_tag [One word or short phrase to categorize this lab.]: 
 author_name [John Smith]:
 author_email [jsmith@company.com]:
 ➜  labs

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ another-lab             my-awesome-learning-lab
 Install it with this command, typically inside a virtual environment:
    ```
    $ pip install cookiecutter
-   ```f
+   ```

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,6 +2,7 @@
     "lab_name": "my-awesome-learning-lab",
     "lab_title": "lab title",
     "lab_slug": "One sentence description of the learning lab.",
+    "lab_tag": "One word or short phrase to categorize this lab.",
     "author_name": "John Smith",
     "author_email": "jsmith@company.com"
 }

--- a/{{cookiecutter.lab_name}}/1.md
+++ b/{{cookiecutter.lab_name}}/1.md
@@ -18,11 +18,7 @@ The objective of this lab is to show how to:
 
 Use bullet points or sub headings to list any prerequisites, such as tools that need to be installed or other labs that should be completed before starting this lab.
 
-## Sub Heading 2 (Optional)
-
-For any intro text that might introduce the steps use a short paragraph less than 100 words.
-
-### Sub Heading 3 (Optional)
+### Sub Heading (Optional)
 
 Lorem ipsum dolor sit amet, massa ligula tellus pellentesque diam, per phasellus natoque etiam vel et. Pellentesque ornare elit ullamcorper pellentesque vel, facilisis lorem fermentum tellus, amet veniam soluta ut magna leo, metus donec aliquam. Lorem nunc ut eleifend quam, lacus magna sit integer orci nam, hendrerit risus quam ante vivamus feugiat, praesent faucibus, pretium donec. Aenean augue
 
@@ -31,7 +27,7 @@ Lorem ipsum dolor sit amet, massa ligula tellus pellentesque diam, per phasellus
 * Lorem ipsum dolor sit amet
 
 
-## Step 1. Lorem Ipsum Dolor
+## Step 1: Lorem Ipsum Dolor
 
 Step 1 is the first major step. It should appear on the first page (1.md). Use action words that are imperatives, such as "Create...", "Understand...", "Set Up...", "Open...", "Define...", etc.
 
@@ -85,11 +81,13 @@ If you need substeps and sequence matters, use numbered steps. Use bullet points
 
 To do blah-blah (you may have a short intro sentence to substeps):
 
-1. Lorem ipsum dolor sit amet, massa ligula tellus pellentesque diam, per phasellus natoque etiam vel et. Pellentesque ornare elit ullamcorper pellentesque vel
-  > Note: This is a note.
-2. Here's a substep with an inline image.
-  ![](assets/images/test_image.png)
-3. Eu malesuada laoreet, et tincidunt arcu, tellus placerat, integer proin augue quis in, luctus sit integer interdum pellentesque consectetuer.
-4. Links look like this: [Here is a link](http://www.cisco.com).
+1. Lorem ipsum dolor sit amet, massa ligula tellus pellentesque diam, per phasellus natoque etiam vel et. Pellentesque ornare elit ullamcorper pellentesque vel.
+  > Note: This is a note that is indented to go with the prior step.
 
-#### Next Step: Provide Title of the Next Step
+1. Here's a substep with an inline image.
+  ![](assets/images/test_image.png)
+
+1. Eu malesuada laoreet, et tincidunt arcu, tellus placerat, integer proin augue quis in, luctus sit integer interdum pellentesque consectetuer.
+1. Links look like this: [Here is a link](http://www.cisco.com).
+
+**Next Step: Provide Title of the Next Step**

--- a/{{cookiecutter.lab_name}}/2.md
+++ b/{{cookiecutter.lab_name}}/2.md
@@ -1,6 +1,6 @@
-## Step 2. The Next Step Title
+# Step 2: The Next Step Title
 
-(The first heading on 2.md should be ## Step 2. Blah-blah)
+(The first heading on 2.md should be # Step 2. Blah-blah)
 
 Lorem ipsum dolor sit amet, massa ligula tellus pellentesque diam...
 
@@ -20,4 +20,4 @@ print(text)
 
 </br>
 
-#### Congratulations! You've Completed [Lab Title Here]
+**Congratulations! You've Completed [Lab Title Here]**

--- a/{{cookiecutter.lab_name}}/{{cookiecutter.lab_name}}.json
+++ b/{{cookiecutter.lab_name}}/{{cookiecutter.lab_name}}.json
@@ -11,7 +11,7 @@
      "file": "2.md"}
   ],
   "tags": [
-	{"title": "DevNet"}
+	{"title": "{{cookiecutter.lab_tag}}"}
   ],
   "related": [
   ],

--- a/{{cookiecutter.lab_name}}/{{cookiecutter.lab_name}}.json
+++ b/{{cookiecutter.lab_name}}/{{cookiecutter.lab_name}}.json
@@ -5,13 +5,13 @@
   "time": 15,
   "byod": true,
   "files": [
-    {"title": "Step 1. Lorem Ipsum Dolor",
+    {"title": "Step 1: Lorem Ipsum Dolor",
      "file":"1.md"},
-    {"title": "Step 2. The Next Step Title",
+    {"title": "Step 2: The Next Step Title",
      "file": "2.md"}
   ],
   "tags": [
-	{"title": "DevNet Labs Template"}
+	{"title": "DevNet"}
   ],
   "related": [
   ],


### PR DESCRIPTION
* Use colons for headings, Step 1:, Step 2: and so on.
* Use heading 1 on second Step page.
* Use bold rather than heading for "Congratulations" line.
* Adds lab_tag to the prompt based on seeing people forgetting to fill that in the JSON file.